### PR TITLE
Fix for requests without an Accept: header

### DIFF
--- a/lib/rack/conneg.rb
+++ b/lib/rack/conneg.rb
@@ -53,7 +53,7 @@ module Rack #:nodoc:#
           if !(accept_all_extensions? || @types.include?(mime_type))
             mime_type = nil
           end
-        else
+        elsif env['HTTP_ACCEPT']
           # Create an array of types out of the HTTP_ACCEPT header, sorted
           # by q value and original order
           if env['HTTP_ACCEPT']


### PR DESCRIPTION
Currently, rack apps that use rack-conneg return a server error for requests that don't have an `Accept:` header because the `#call` method doesn't check to ensure there is one before it tries to `#split` the value. This patch just changes the unconditional `else` to a conditional one, which will cause requests without an `Accept` header to fall through to the default.
